### PR TITLE
[BUGFIX] Set tx_realurl_pathoverride field to 1

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -6,3 +6,4 @@ $GLOBALS['TCA']['pages']['columns']['tx_realurl_pathsegment']['config']['readOnl
 unset($GLOBALS['TCA']['pages']['columns']['tx_realurl_pathsegment']['config']['eval']);
 $GLOBALS['TCA']['pages']['columns']['tx_realurl_pathoverride']['config']['type'] = 'passthrough';
 $GLOBALS['TCA']['pages']['columns']['tx_realurl_exclude']['config']['type'] = 'passthrough';
+$GLOBALS['TCA']['pages']['columns']['tx_realurl_pathoverride']['config']['default'] = 1;


### PR DESCRIPTION
If a editor copies a page the tx_realurl_pathoverride field is set to 0. That leads that the URL is set incorrectly to the tx_realurl_pathdata table.