### PR TITLE
Properly initialize command again

### DIFF
--- a/Classes/Command/UpdateSlugsCommand.php
+++ b/Classes/Command/UpdateSlugsCommand.php
@@ -27,6 +27,7 @@ final class UpdateSlugsCommand extends Command
         private PageCollection $pageCollection,
         private PageSlugProcessor $slugProcessor,
     ) {
+        parent::__construct();
     }
 
     /**


### PR DESCRIPTION
When adding DI via constructor here, the essential parent constructor call was forgotten. This is added now.