### PR TITLE
Skip XSD validation in XML lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         ],
         "lint:php": "parallel-lint --show-deprecated --exclude vendor --exclude web .",
         "lint:style": "php-cs-fixer fix --dry-run --diff",
-        "lint:xml": "xmllint --pattern '*.xml,*.svg' --recursive 0 .",
+        "lint:xml": "xmllint --pattern '*.xml,*.svg' --recursive 0 --skip-xsd .",
         "test": [
             "@test:unit",
             "@test:functional"


### PR DESCRIPTION
We don't care about this in particular and in case an XSD schema is located remotely and the server is down, XML linting will fail.

See https://github.com/pagemachine/typo3-flat-urls/actions/runs/10157757486/job/28088458184