### PR TITLE
Drop support for PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
         typo3:
           - ^11.5
           - ^12.4
-        include:
-          - php: '8.0'
-            typo3: ^11.5
 
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/dbal": "^2.0 || ^3.0",
         "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-handler": "^1.0",


### PR DESCRIPTION
This is EOL since November 2023.

See https://www.php.net/eol.php